### PR TITLE
Fixes error where path is incorrect if plugin is symlinked in

### DIFF
--- a/age-verify.php
+++ b/age-verify.php
@@ -165,7 +165,7 @@ class Age_Verify {
 	 */
 	public function enqueue_styles() {
 		
-		wp_enqueue_style( 'av-styles', $this->plugin_url . 'assets/styles.css' );
+		wp_enqueue_style( 'av-styles', plugins_url() . '/' . basename(dirname(__FILE__)) . '/assets/styles.css');
 	}
 	
 	/**


### PR DESCRIPTION
Hey Chase - 

For various reasons, we symlink our plugins into our wp-content folder.  The way this plugin calculates its style path was causing an error.  We didn't see this error on other plugins for whatever reason.  In any case, this seems to fix the problem.

Note: I'm not a wordpress expert, so I'm sure there's a more idiomatic way to do this :)
