### PR TITLE
database not getting read for minutes value in settings

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -104,8 +104,7 @@ function av_get_visitor_age( $year, $month, $day ) {
  */
 function av_get_cookie_duration() {
 	
-	$cookie_duration = 720;
-	
+
 	/**
 	 * Filter the cookie duration.
 	 * 
@@ -113,9 +112,13 @@ function av_get_cookie_duration() {
 	 * 
 	 * @param int $cookie_duration The cookie duration.
 	 */
-	$cookie_duration = apply_filters( 'av_cookie_duration', $cookie_duration );
+
+ 	$cookie_default_duration = get_option( '_av_cookie_duration', 720 ); 
+
+	$cookie_duration = apply_filters( 'av_cookie_duration', $cookie_default_duration );
 	
 	return (int) $cookie_duration;
+}
 }
 
 /**


### PR DESCRIPTION
It seems that the av_get_cookie_duration() function was not reading the database value that is set when you go to the age-verify settings and type in the minutes.
I added " $cookie_default_duration = get_option( '_av_cookie_duration', 720 )" which
reads the value that is set. If it is not able to read the database value, then the default of 720 minutes is used.