### PR TITLE
av_before_heading filter

### DIFF
--- a/includes/class-age-verify.php
+++ b/includes/class-age-verify.php
@@ -237,6 +237,8 @@ final class Age_Verify {
 			<?php do_action( 'av_before_modal' ); ?>
 
 			<div id="av-overlay">
+				
+				<?php echo apply_filters('av_before_heading', ''); ?>
 
 				<h1><?php esc_html_e( av_get_the_heading() ); ?></h1>
 


### PR DESCRIPTION
The section above the heading would be useful to have as a filter. It could be worked into the option screen too but for now I have a couple clients that need intro text before the header so I've added that in locally on our copy.